### PR TITLE
removing glob in makem.js

### DIFF
--- a/tools/makem.js
+++ b/tools/makem.js
@@ -7,7 +7,6 @@ var
 	exec = require('child_process').exec,
 	path = require('path'),
 	fs = require('fs'),
-	glob = require('glob'),
 	child;
 
 var HAVE_NFT = 1;


### PR DESCRIPTION
From this issue https://github.com/Carnaux/NFT-Marker-Creator/issues/16 and PR https://github.com/Carnaux/NFT-Marker-Creator/pull/17 [comment](https://github.com/Carnaux/NFT-Marker-Creator/pull/17#issuecomment-568186806) 
**glob** is not needed anymore in **makem.js**, we can safely remove it.
