### PR TITLE
fix metadata problem - adding -onlyConfidence option

### DIFF
--- a/app.js
+++ b/app.js
@@ -16,9 +16,16 @@ var validImageExt = [".jpg",".jpeg",".png"];
 
 var srcImage;
 
+var outputPath = '/output/';
+
 var buffer;
 
 var foundInputPath = {
+    b: false,
+    i: -1
+}
+
+var foundOutputPath = {
     b: false,
     i: -1
 }
@@ -48,6 +55,10 @@ Module.onRuntimeInitialized = async function(){
             noDemo = true;
         }else if(process.argv[j] == "-onlyConfidence"){
             onlyConfidence = true;
+        }else if(process.argv[j].indexOf('-o') !== -1 || process.argv[j].indexOf('-O') !== -1){
+            foundOutputPath.b = true;
+            foundOutputPath.i = j+1;
+            j++;
         }else {
             params.push(process.argv[j]);
         }
@@ -58,6 +69,16 @@ Module.onRuntimeInitialized = async function(){
         process.exit(1);
     }else{
         srcImage = path.join(__dirname, process.argv[foundInputPath.i]);
+    }
+
+    if(foundOutputPath.b){
+        // outputPath = path.join(__dirname, process.argv[foundOutputPath.i]);
+        outputPath = process.argv[foundOutputPath.i];
+        if(!outputPath.startsWith('/'))
+            outputPath = '/'+outputPath;
+        if(!outputPath.endsWith('/'))
+            outputPath += '/';
+        console.log('Set output path: ' + outputPath);
     }
 
     let fileNameWithExt = path.basename(srcImage);
@@ -84,8 +105,13 @@ Module.onRuntimeInitialized = async function(){
         buffer = fs.readFileSync(srcImage);
     }
 
-    if(!fs.existsSync(path.join(__dirname, '/output/'))){
-        fs.mkdirSync(path.join(__dirname, '/output/'));
+    
+    // if(!fs.existsSync(path.join(__dirname, '/output/'))){
+    //     fs.mkdirSync(path.join(__dirname, '/output/'));
+    // }
+    console.log('Check output path: ' + path.join(__dirname, outputPath));
+    if(!fs.existsSync(path.join(__dirname, outputPath))){
+        fs.mkdirSync(path.join(__dirname, outputPath));
     }
 
     if (extName.toLowerCase() == ".jpg" || extName.toLowerCase() == ".jpeg") {
@@ -150,9 +176,13 @@ Module.onRuntimeInitialized = async function(){
     let contentFset = Module.FS.readFile(filenameFset);
     let contentFset3 = Module.FS.readFile(filenameFset3);
 
-    fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext, content);
-    fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext2, contentFset);
-    fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext3, contentFset3);
+    // fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext, content);
+    // fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext2, contentFset);
+    // fs.writeFileSync(path.join(__dirname, '/output/') + fileName + ext3, contentFset3);
+
+    fs.writeFileSync(path.join(__dirname, outputPath) + fileName + ext, content);
+    fs.writeFileSync(path.join(__dirname, outputPath) + fileName + ext2, contentFset);
+    fs.writeFileSync(path.join(__dirname, outputPath) + fileName + ext3, contentFset3);
 
     if(!noDemo){
         console.log("\nFinished marker creation!\nNow configuring demo! \n")

--- a/app.js
+++ b/app.js
@@ -261,7 +261,7 @@ function extractExif(buf) {
                 if (metadata == null || metadata == undefined || Object.keys(metadata).length == undefined || Object.keys(metadata).length <= 0) {
                     // console.log(metadata);
                     let ret = await imageMagickIdentify(srcImage);
-                    //console.log('ret:', ret);
+                    console.log('ret:', ret);
                     {
                     if(ret.err){
                         console.log(ret.err);
@@ -302,11 +302,13 @@ function extractExif(buf) {
                             if(resolutions.length == 2) {
                                 dpi = Math.min(parseInt(resolutions[0]), parseInt(resolutions[1]));
                                 if (dpi == null || dpi == undefined || dpi == NaN) {
-                                    console.log("\nWARNING: No DPI value found! Using 72 as default value!\n")
+                                    // console.log("\nWARNING: No DPI value found! Using 72 as default value!\n")
                                     dpi = 72;
                                 }
                             }
                             
+                        } else {
+                            dpi = 72;
                         }
                         
                         imageData.dpi = dpi;

--- a/app.js
+++ b/app.js
@@ -136,7 +136,7 @@ Module.onRuntimeInitialized = async function(){
 
     if(onlyConfidence) {
         console.log("%f", confidence.l);
-        process.exit(1);
+        process.exit(0);
     }
 
     console.log("\nConfidence level: [" + txt + "] %f/5 || Entropy: %f || Current max: 5.17 min: 4.6", confidence.l, confidence.e)

--- a/app.js
+++ b/app.js
@@ -212,6 +212,8 @@ Module.onRuntimeInitialized = async function(){
     
         console.log("Finished!\nTo run demo use: 'npm run demo'");
     }
+
+    process.exit(0);
 }
 
 async function useJPG(buf) {

--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ var foundInputPath = {
 
 var noConf = false;
 var noDemo = false;
+var onlyConfidence = false;
 
 var imageData = {
     sizeX: 0,
@@ -44,6 +45,8 @@ Module.onRuntimeInitialized = function(){
             noConf = true;
         }else if(process.argv[j] == "-noDemo"){
             noDemo = true;
+        }else if(process.argv[j] == "-onlyConfidence"){
+            onlyConfidence = true;
         }else {
             params.push(process.argv[j]);
         }
@@ -104,8 +107,14 @@ Module.onRuntimeInitialized = function(){
         txt = str.join("");
     }
 
+    if(onlyConfidence) {
+        console.log("%f", confidence.l);
+        process.exit(1);
+    }
+
     console.log("\nConfidence level: [" + txt + "] %f/5 || Entropy: %f || Current max: 5.17 min: 4.6", confidence.l, confidence.e)
     
+
     if(!noConf){
         const answer = readlineSync.question(`\nDo you want to continue? (Y/N)\n`);
 

--- a/app.js
+++ b/app.js
@@ -217,7 +217,7 @@ function useJPG(buf) {
             console.log("\n" + err + "\n");
             process.exit(1);
         } else {
-            if (metadata == null || metadata == undefined || Object.keys(metadata).length == undefined) {
+            if (metadata == null || metadata == undefined || Object.keys(metadata).length == undefined || Object.keys(metadata).length <= 0) {
                 var answer = readlineSync.question('The EXIF info of this image is empty or it does not exist. Do you want to inform its properties manually?[y/n]\n');
 
                 if (answer == "y") {

--- a/app.js
+++ b/app.js
@@ -208,7 +208,7 @@ function useJPG(buf) {
             console.log("\n" + err + "\n");
             process.exit(1);
         } else {
-            if (metadata == null || metadata == undefined || metadata.length == undefined) {
+            if (metadata == null || metadata == undefined || Object.keys(metadata).length == undefined) {
                 var answer = readlineSync.question('The EXIF info of this image is empty or it does not exist. Do you want to inform its properties manually?[y/n]\n');
 
                 if (answer == "y") {

--- a/demo/nft.html
+++ b/demo/nft.html
@@ -8,7 +8,7 @@
 <!-- ar.js -->
 <script src='/static/ar-nft.js'></script>
 <!-- DON'T REMOVE OR CHANGE THIS LINE -->
-<script>MARKER_NAME = 'win10'</script>
+<script>MARKER_NAME = 'stampante1'</script>
 <script>THREEx.ArToolkitContext.baseURL = './static/resources'</script>
 
 <body style='position: absolute; top: 0; left: 0; width: 100%; height: 100%; margin : 0px; overflow: hidden;'>

--- a/demo/nft.html
+++ b/demo/nft.html
@@ -8,7 +8,7 @@
 <!-- ar.js -->
 <script src='/static/ar-nft.js'></script>
 <!-- DON'T REMOVE OR CHANGE THIS LINE -->
-<script>MARKER_NAME = 'tempd'</script>
+<script>MARKER_NAME = 'win10'</script>
 <script>THREEx.ArToolkitContext.baseURL = './static/resources'</script>
 
 <body style='position: absolute; top: 0; left: 0; width: 100%; height: 100%; margin : 0px; overflow: hidden;'>

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,6 +231,11 @@
       "resolved": "https://registry.npmjs.org/imageinfo/-/imageinfo-1.0.4.tgz",
       "integrity": "sha1-HdJFbsuW/DlfCqEXnEZ9+z1deio="
     },
+    "imagemagick": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/imagemagick/-/imagemagick-0.1.3.tgz",
+      "integrity": "sha1-dIPOoJO02fLi85aFetyIIbU3xWo="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "glob": "^7.1.6",
+    "imagemagick": "^0.1.3",
     "inkjet": "^2.1.2",
     "jpeg-js": "^0.4.0",
     "pngjs": "^3.4.0",


### PR DESCRIPTION
metadata is an object so the length is always undefined; It's needed to check keys length in order to check if the metadata object is empty
adding onlyConfidence option that returns only the confidence of the input image