### PR TITLE
Update build instructions, support for emscripten 2.0.30 and macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ This repository creates the NftMakerCreator.js file used in the marker creator(m
 
 ### Important
 
-If you want to build for the web version with frameworks like Vue.js you need to add the flags below.
+If you want to build for the web version with frameworks like Vue.js you need to uncomment the flags below, found on line 121 of `tools/mekem.js`.
 
-FLAGS += ' -s MODULARIZE';  < Line 121 >
+```
+FLAGS += ' -s MODULARIZE';
 FLAGS += ' -s EXPORT_ES6=1';
 FLAGS += ' -s USE_ES6_IMPORT_META=0';
+```
 
 ### Recommended: Build using Docker
 
@@ -26,21 +28,24 @@ FLAGS += ' -s USE_ES6_IMPORT_META=0';
 ### ⚠️ Not recommended ⚠️ : Build local with manual emscripten setup
 
 To prevent issues with Emscripten setup and to not have to maintain several build environments (macOS, Windows, Linux) we only maintain the **Build using Docker**. Following are the instructions of the last know build on Linux which we verified are working. **Use at own risk.**
-** Not working on macOS!**
 
 1. Install build tools
   1. Install node.js (https://nodejs.org/en/)
   2. Install python2 (https://www.python.org/downloads/)
   3. Install emscripten (https://emscripten.org/docs/getting_started/downloads.html#download-and-install)
-     We used emscripten version **1.39.5-fastcomp** ~~1.38.44-fastcomp~~
-
-2. Clone ARToolKit5 project to get the latest source files. From within NFT-Marker-Creator directory do `git submodule update --init`. If you already cloned ARToolKit5 to a different directory you can:
-  - create a link in the `NFT-Marker-Creator/emscripten/` directory that points to ARToolKit5 (`NFT-Marker-Creator/emscripten/artoolkit5`)
-  - or, set the `ARTOOLKIT5_ROOT` environment variable to point to your ARToolKit5 clone
-  - or, change the `tools/makem.js` file to point to your artoolkit5 clone (line 20)
-
+    - We used emscripten version 2.0.30
+    - On macOS, you can install using [brew](https://brew.sh/): `brew install emscripten`
+2. Clone [ARToolKit5 project](https://github.com/artoolkitx/artoolkit5) somewhere to get the latest source files. Then:
+  - configure/build ARToolKit
+    - on macOS, open `ARToolkit5.xcodeproj` and build
+      - you may need to modify ARToolKit5 > Build Settings > Apple Clang - Custom Compiler Flags > Other C Flags and remove "-march=core2"
+  - point NFT-Marker-Creator to your ARToolKit5
+    - create a link in the `NFT-Marker-Creator/emscripten/` directory that points to ARToolKit5 (`NFT-Marker-Creator/emscripten/artoolkit5`)
+    - or, set the `ARTOOLKIT5_ROOT` environment variable to point to your ARToolKit5 clone
+    - or, change the `tools/makem.js` file to point to your artoolkit5 clone (line 20)
 3. Building
   1. Make sure `EMSCRIPTEN` env variable is set (e.g. `EMSCRIPTEN=/usr/lib/emsdk_portable/emscripten/master/ node tools/makem.js`
+    - This is not necessary if you installed emscripten using brew on macOS
   3. Run `npm install`
   4. Run `npm run build-local`
 

--- a/tools/makem.js
+++ b/tools/makem.js
@@ -122,7 +122,7 @@ FLAGS += ' -s FORCE_FILESYSTEM=1';
 // FLAGS += ' -s EXPORT_ES6=1';
 // FLAGS += ' -s USE_ES6_IMPORT_META=0';
 
-var WASM_FLAGS = ' -s BINARYEN_TRAP_MODE=clamp';
+var WASM_FLAGS = ' ';
 var PRE_FLAGS = ' --pre-js ' + path.resolve(__dirname, '../emscripten/wasm_loader.js') +' ';
 
 var EXPORTED_FUNCTIONS = ' -s EXPORTED_FUNCTIONS=["_createImageSet"] -s EXTRA_EXPORTED_RUNTIME_METHODS=["FS, writeStringToMemory"] ';
@@ -171,7 +171,7 @@ function clean_builds() {
 
 var compile_arlib = format(EMCC + ' ' + INCLUDES + ' '
 	+ ar_sources.join(' ')
-	+ FLAGS + ' ' + DEFINES + ' -o {OUTPUT_PATH}libar.bc ',
+	+ FLAGS + ' ' + DEFINES + ' -r -o {OUTPUT_PATH}libar.bc ',
 		OUTPUT_PATH);
 
  var compile_kpm = format(EMCC + ' ' + INCLUDES + ' '


### PR DESCRIPTION
- Clarified instructions on enabling ES6 modules
- Updated to build on emscripten 2.0.30
- Updated build instructions with macOS support

I couldn't get the Docker build to work, and ended up fixing the build on macOS using the latest version of emscripten.
I have a lot more suggestions for this project in general (don't publish builds to git, use Github releases, use parameters instead of a string with flags, etc.), and I really would like to make it run much, much faster on the web, so I'm hoping to submit more PRs in the future.